### PR TITLE
Use module generation macro

### DIFF
--- a/lib/open_telemetry.ex
+++ b/lib/open_telemetry.ex
@@ -1,4 +1,28 @@
 defmodule OpenTelemetry do
+  # Shortcuts that operate implicitly on the current Tracer
+  defdelegate start_span(name), to: :otel
+  defdelegate start_span(name, options), to: :otel
+  defdelegate with_span(span_ctx), to: :otel
+  defdelegate with_span(span_ctx, fun), to: :otel
+  defdelegate current_span_ctx(), to: :otel
+  defdelegate end_span(), to: :otel
+
+  # Manage the Tracer
+  defdelegate set_default_tracer(tracer), to: :opentelemetry
+  defdelegate get_tracer(), to: :opentelemetry
+  defdelegate get_tracer(name), to: :opentelemetry
+
+  # Helpers to build OpenTelemetry structured types
+  defdelegate timestamp(), to: :opentelemetry
+  defdelegate links(link_list), to: :opentelemetry
+  defdelegate link(trace_id, span_id, attributes, trace_state), to: :opentelemetry
+  defdelegate event(name, attributes), to: :opentelemetry
+  defdelegate timed_event(timestamp, name, attributes), to: :opentelemetry
+  defdelegate timed_event(timestamp, event), to: :opentelemetry
+  defdelegate timed_events(timed_event_list), to: :opentelemetry
+  defdelegate status(code, message), to: :opentelemetry
+
+  # Do these need to be in a public API?
   defdelegate generate_trace_id(), to: :opentelemetry
   defdelegate generate_span_id(), to: :opentelemetry
 end

--- a/lib/open_telemetry/span.ex
+++ b/lib/open_telemetry/span.ex
@@ -1,0 +1,13 @@
+defmodule OpenTelemetry.Span do
+  @moduledoc false
+
+  defdelegate start_span(tracer, span_name, options), to: :ot_span
+  defdelegate end_span(tracer, span_ctx), to: :ot_span
+  defdelegate get_ctx(tracer, span), to: :ot_span
+  defdelegate is_recording_events(tracer, span_ctx), to: :ot_span
+  defdelegate set_attribute(tracer, span_ctx, key, value), to: :ot_span
+  defdelegate set_attributes(tracer, span_ctx, attributes), to: :ot_span
+  defdelegate add_events(tracer, span_ctx, events), to: :ot_span
+  defdelegate set_status(tracer, span_ctx, status), to: :ot_span
+  defdelegate update_name(tracer, span_ctx, name), to: :ot_span
+ end

--- a/lib/open_telemetry/tracer.ex
+++ b/lib/open_telemetry/tracer.ex
@@ -1,10 +1,48 @@
 defmodule OpenTelemetry.Tracer do
   @moduledoc false
 
-  defdelegate start_span(tracer, span_name, options), to: :ot_tracer
+  defmacro __using__(tracer) do
+    case tracer do
+      [] ->
+        quote do
+          defp __get_tracer__() do
+            :opentelemetry.get_tracer()
+          end
+        end
+      _ ->
+        quote do
+          defp __get_tracer__() do
+            :opentelemetry.get_tracer(unquote(tracer))
+          end
+        end
+    end
+  end
+
+  defmacro start_span(name, opts \\ quote(do: %{}), do: block) do
+    quote do
+      tracer = __get_tracer__()
+      :ot_tracer.start_span(tracer, unquote(name), unquote(opts))
+      try do
+        unquote(block)
+      after
+        :ot_tracer.end_span(tracer)
+      end
+    end
+  end
+
+  defmacro with_span(span_ctx) do
+    quote do
+      :ot_tracer.with_span(__get_tracer__(), unquote(span_ctx))
+    end
+  end
+
   defdelegate with_span(tracer, span_ctx), to: :ot_tracer
-  defdelegate with_span(tracer, span_ctx, fun), to: :ot_tracer
+
+  defmacro current_span_ctx() do
+    quote do
+      :ot_tracer.current_span_ctx(__get_tracer__())
+    end
+  end
+
   defdelegate current_span_ctx(tracer), to: :ot_tracer
-  defdelegate get_binary_format(tracer), to: :ot_tracer
-  defdelegate get_http_text_format(tracer), to: :ot_tracer
 end

--- a/lib/open_telemetry/tracer.ex
+++ b/lib/open_telemetry/tracer.ex
@@ -1,48 +1,91 @@
 defmodule OpenTelemetry.Tracer do
-  @moduledoc false
+  @moduledoc """
+  Defines tracer module.
 
+  ## Example
+
+      defmodule Tracer do
+        use #{inspect __MODULE__}
+      end
+  """
+
+  # TODO:
+  # - what options are possible there?
+  # - should we use `:otp_app` attribute to allow configuring tracer within
+  #   given application?
   defmacro __using__(tracer) do
-    case tracer do
-      [] ->
-        quote do
-          defp __get_tracer__() do
-            :opentelemetry.get_tracer()
-          end
-        end
-      _ ->
-        quote do
-          defp __get_tracer__() do
-            :opentelemetry.get_tracer(unquote(tracer))
-          end
-        end
-    end
-  end
+    quote bind_quoted: [module: __MODULE__, tracer: tracer] do
+      @behaviour module
 
-  defmacro start_span(name, opts \\ quote(do: %{}), do: block) do
-    quote do
-      tracer = __get_tracer__()
-      :ot_tracer.start_span(tracer, unquote(name), unquote(opts))
-      try do
-        unquote(block)
-      after
-        :ot_tracer.end_span(tracer)
+      # TODO: Maybe we should make it public?
+      defp __tracer__, do: :opentelemetry.get_tracer(unquote(tracer))
+
+      @impl module
+      def start_span(name, opts \\ []), do: :ot_tracer.start_span(__tracer__(), name, opts)
+
+      @impl module
+      def end_span(name, span_ctx \\ current_span()),
+        do: :ot_tracer.end_span(__tracer__(), span_ctx)
+
+      @impl module
+      def current_span(), do: :ot_tracer.current_span(__tracer__())
+
+      @impl module
+      def with_span(name, opts \\ [], func) do
+        tracer = __tracer__()
+        span_ctx = :ot_tracer.start_span(tracer, name, opts)
+
+        try do
+          func.()
+          # TODO: Set status on errors
+          # catch
+          #   kind, value ->
+          #     # Mock, the real handling will probavly look a little bit different
+          #     set_status(Exception.normalize(kind, value, __STACKTRACE__)
+          #     :erlang.raise(kind, value, __STACKTRACE__)
+        after
+          :ot_tracer.end_span(tracer, span_ctx)
+        end
       end
     end
   end
 
-  defmacro with_span(span_ctx) do
-    quote do
-      :ot_tracer.with_span(__get_tracer__(), unquote(span_ctx))
-    end
-  end
+  @doc """
+  Starts new span.
+  """
+  @callback start_span(name :: :opentelemetry.span_name(), opts :: :ot_span.start_opts()) ::
+              :opentelemetry.span_ctx()
 
-  defdelegate with_span(tracer, span_ctx), to: :ot_tracer
+  @doc """
+  Ends span.
 
-  defmacro current_span_ctx() do
-    quote do
-      :ot_tracer.current_span_ctx(__get_tracer__())
-    end
-  end
+  By default it ends current span.
+  """
+  @callback end_span(span_ctx :: :opentelemetry.span_ctx()) :: :ok
 
-  defdelegate current_span_ctx(tracer), to: :ot_tracer
+  @doc """
+  Return currently active span.
+  """
+  @callback current_span_ctx() :: :opentelemetry.span_ctx() | :undefined
+
+  @doc """
+  Runs given function within new span and closes it afterwards.
+
+  ## Example
+
+      parent_span = Tracer.current_span_ctx()
+
+      Tracer.with_span("foo", fn ->
+        parent_span != Tracer.current_span_ctx()
+      end)
+
+      parent_span == Tracer.current_span_ctx()
+  """
+  @callback with_span(
+              name :: :opentelemetry.span_name(),
+              opts :: :ot_span.start_opts(),
+              func :: (() -> return)
+            ) ::
+              return
+            when return: any()
 end

--- a/lib/open_telemetry/tracer.ex
+++ b/lib/open_telemetry/tracer.ex
@@ -1,0 +1,10 @@
+defmodule OpenTelemetry.Tracer do
+  @moduledoc false
+
+  defdelegate start_span(tracer, span_name, options), to: :ot_tracer
+  defdelegate with_span(tracer, span_ctx), to: :ot_tracer
+  defdelegate with_span(tracer, span_ctx, fun), to: :ot_tracer
+  defdelegate current_span_ctx(tracer), to: :ot_tracer
+  defdelegate get_binary_format(tracer), to: :ot_tracer
+  defdelegate get_http_text_format(tracer), to: :ot_tracer
+end

--- a/test/open_telemetry_test.exs
+++ b/test/open_telemetry_test.exs
@@ -1,6 +1,8 @@
 defmodule OpenTelemetryTest do
   use ExUnit.Case, async: true
 
+  use OpenTelemetry.Tracer
+
   test "current_span tracks nesting" do
     _ctx1 = OpenTelemetry.start_span("span-1")
     ctx2 = OpenTelemetry.start_span("span-2")
@@ -16,4 +18,13 @@ defmodule OpenTelemetryTest do
     OpenTelemetry.end_span()
     assert ctx1 == OpenTelemetry.current_span_ctx()
   end
+
+  test "macro start_span" do
+    OpenTelemetry.Tracer.start_span "span-1" do
+      OpenTelemetry.Tracer.start_span "span-2" do
+        # test something
+      end
+    end
+  end
+
 end

--- a/test/open_telemetry_test.exs
+++ b/test/open_telemetry_test.exs
@@ -1,0 +1,19 @@
+defmodule OpenTelemetryTest do
+  use ExUnit.Case, async: true
+
+  test "current_span tracks nesting" do
+    _ctx1 = OpenTelemetry.start_span("span-1")
+    ctx2 = OpenTelemetry.start_span("span-2")
+
+    assert ctx2 == OpenTelemetry.current_span_ctx()
+  end
+
+  test "closing a span makes the parent current" do
+    ctx1 = OpenTelemetry.start_span("span-1")
+    ctx2 = OpenTelemetry.start_span("span-2")
+
+    assert ctx2 == OpenTelemetry.current_span_ctx()
+    OpenTelemetry.end_span()
+    assert ctx1 == OpenTelemetry.current_span_ctx()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
This is concept borrowed from Ecto.Repo, where we define behaviour with all functions used in the module for sake of documentation, and then use `__using__/1` macro to generate all needed functions.

There are still some features to be done (and it also depends on open-telemetry/opentelemetry-erlang-api#14). But the overall idea is present.